### PR TITLE
Add support for compact point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,8 +316,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "elliptic-curve"
 version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee681bf25de1aad7cd02ccc7525d7b4bfab7be2493dbe3ee18d93f86eb3dcf3e"
+source = "git+https://github.com/helium/traits.git?branch=rg/compact#c94b54ebd908c195638e98904848de9da8e99581"
 dependencies = [
  "base64ct",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "p256",
     "p384",
 ]
+
+[patch.crates-io]
+elliptic-curve = { git = "https://github.com/helium/traits.git", branch = "rg/compact" }

--- a/k256/src/arithmetic/affine.rs
+++ b/k256/src/arithmetic/affine.rs
@@ -124,6 +124,7 @@ impl FromEncodedPoint<Secp256k1> for AffinePoint {
     fn from_encoded_point(encoded_point: &EncodedPoint) -> Option<Self> {
         match encoded_point.coordinates() {
             sec1::Coordinates::Identity => Some(Self::identity()),
+            sec1::Coordinates::Compact { .. } => None,
             sec1::Coordinates::Compressed { x, y_is_odd } => {
                 AffinePoint::decompress(x, Choice::from(y_is_odd as u8)).into()
             }

--- a/p256/src/lib.rs
+++ b/p256/src/lib.rs
@@ -142,6 +142,11 @@ impl elliptic_curve::weierstrass::PointCompression for NistP256 {
     const COMPRESS_POINTS: bool = false;
 }
 
+impl elliptic_curve::weierstrass::PointCompaction for NistP256 {
+    /// NIST P-256 points are typically not compact.
+    const COMPACT_POINTS: bool = false;
+}
+
 #[cfg(feature = "jwk")]
 #[cfg_attr(docsrs, doc(cfg(feature = "jwk")))]
 impl elliptic_curve::JwkParameters for NistP256 {


### PR DESCRIPTION
The goal here is to allow "compacting" a point on an elliptic curve. We only added support for `NistP256` to have lower surface area for code changes.

Note that not all points on a curve can be compacted (i.e. represented by only their `X` coordinate as the `Y` coordinate can be derived from the curve equation and `X` itself).